### PR TITLE
Avoid port conflicts

### DIFF
--- a/xdebug.ini
+++ b/xdebug.ini
@@ -2,5 +2,5 @@ xdebug.remote_enable = 1
 xdebug.remote_autostart = 1
 xdebug.remote_connect_back = 1
 xdebug.remote_host = host.docker.internal
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
 xdebug.idekey = PHPSTORM


### PR DESCRIPTION
Port 9000 is used by php-fpm, so we need a different port for xdebug.

Refs RoundingWell/docker-php-prod#2